### PR TITLE
fix(cache-missed): remove extended_bounds so that the query always hits the cache

### DIFF
--- a/gravitee-repository-elasticsearch/src/main/resources/freemarker/analyticsRequest.ftl
+++ b/gravitee-repository-elasticsearch/src/main/resources/freemarker/analyticsRequest.ftl
@@ -27,11 +27,7 @@
          "date_histogram":{
             "field":"@timestamp",
             "interval":"${interval}",
-            "min_doc_count":0,
-            "extended_bounds":{
-               "min":${from},
-               "max":${to}
-            }
+            "min_doc_count":0
          },
          "aggregations":{
             "by_application":{

--- a/gravitee-repository-elasticsearch/src/main/resources/freemarker/dateHistogram.ftl
+++ b/gravitee-repository-elasticsearch/src/main/resources/freemarker/dateHistogram.ftl
@@ -35,11 +35,7 @@
       "date_histogram": {
         "field": "@timestamp",
         "interval": "${query.timeRange().interval().toMillis()}ms",
-        "min_doc_count": 0,
-        "extended_bounds": {
-          "min": ${query.timeRange().range().from()},
-          "max": ${query.timeRange().range().to()}
-        }
+        "min_doc_count": 0
       }
 <#if query.aggregations()?has_content>
       ,

--- a/gravitee-repository-elasticsearch/src/main/resources/freemarker/healthcheck/avg-date-histogram.ftl
+++ b/gravitee-repository-elasticsearch/src/main/resources/freemarker/healthcheck/avg-date-histogram.ftl
@@ -25,11 +25,7 @@
           "_key" : "asc"
         },
         "keyed" : false,
-        "min_doc_count" : 0,
-        "extended_bounds" : {
-          "min" : ${query.timeRange().range().from()},
-          "max" : ${query.timeRange().range().to()}
-        }
+        "min_doc_count" : 0
       }
 <#if query.aggregations()?has_content>
       ,


### PR DESCRIPTION
Hello,

I propose you this PR I've tested with our OPS.
The details are in the issue gravitee-io/issues#1545

Nicolas