### PR TITLE
Configurable timeout for the analytics repository client

### DIFF
--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
@@ -39,7 +39,7 @@ public class RepositoryConfiguration {
 
 	@Autowired
 	private Environment environment;
-	
+
 	/**
 	 * Prefix index name. 
 	 */
@@ -57,7 +57,7 @@ public class RepositoryConfiguration {
 	 */
 	@Value("${analytics.elasticsearch.security.username:#{null}}")
 	private String username;
-	
+
 	/**
 	 * Elasticsearch basic oauth password. 
 	 */
@@ -65,12 +65,18 @@ public class RepositoryConfiguration {
 	private String password;
 
 	/**
+	 * Configurable request timeout for http requests to elasticsearch
+	 */
+	@Value("${analytics.elasticsearch.client.timeout:10000}")
+	private Long requestTimeout;
+
+	/**
 	 * Elasticsearch endpoints
 	 */
 	private List<Endpoint> endpoints;
 
 	private Map<String, String> crossClusterMapping;
-	
+
 	public String getUsername() {
 		return username;
 	}
@@ -85,6 +91,11 @@ public class RepositoryConfiguration {
 
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	public Long getRequestTimeout()
+	{
+		return requestTimeout;
 	}
 
 	public List<Endpoint> getEndpoints() {

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
@@ -70,16 +70,17 @@ public class ElasticsearchRepositoryConfiguration {
     public FreeMarkerComponent freeMarckerComponent() {
         return new FreeMarkerComponent();
     }
-    
+
     @Bean
     public Client client(RepositoryConfiguration repositoryConfiguration) {
         HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
         clientConfiguration.setEndpoints(repositoryConfiguration.getEndpoints());
         clientConfiguration.setUsername(repositoryConfiguration.getUsername());
         clientConfiguration.setPassword(repositoryConfiguration.getPassword());
+        clientConfiguration.setRequestTimeout(repositoryConfiguration.getRequestTimeout());
         return new HttpClient(clientConfiguration);
     }
-    
+
     @Bean
     public IndexNameGenerator indexNameGenerator(RepositoryConfiguration repositoryConfiguration, Client client) {
         // Wait for a connection to ES and retry each 5 seconds

--- a/gravitee-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/ElasticsearchRepositoryConfigurationTest.java
+++ b/gravitee-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/ElasticsearchRepositoryConfigurationTest.java
@@ -57,4 +57,10 @@ public class ElasticsearchRepositoryConfigurationTest {
         Assert.assertTrue(configuration.hasCrossClusterMapping());
         Assert.assertEquals("cluster1", configuration.getCrossClusterMapping().get("tenant1"));
     }
+
+    @Test
+    public void shouldHaveClientTimeout() {
+        Assert.assertNotNull(configuration.getRequestTimeout());
+        Assert.assertEquals(30000, configuration.getRequestTimeout().longValue());
+    }
 }

--- a/gravitee-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
+++ b/gravitee-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
@@ -9,3 +9,5 @@ analytics:
       mapping:
         tenant1: cluster1
         tenant2: cluster2
+    client:
+      timeout: 30000


### PR DESCRIPTION
Configurable timeout to handle long running elasticsearch queries in case of a large time window or many statistics data

fix gravitee-io/issues#1920