### PR TITLE
fix(elasticsearch): Include an empty user-agent field value when pipe…

### DIFF
--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es2x/index/request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es2x/index/request.ftl
@@ -57,8 +57,8 @@
   <#if metrics.getHost()??>
   ,"host":"${metrics.getHost()}"
   </#if>
-  <#if metrics.getUserAgent()??>
-  ,"user-agent":"${metrics.getUserAgent()}"
+  <#if metrics.getUserAgent()?? || pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()!""}"
   </#if>
   <#if metrics.getUser()??>
   ,"user":"${metrics.getUser()}"

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es5x/index/request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es5x/index/request.ftl
@@ -57,8 +57,8 @@
   <#if metrics.getHost()??>
   ,"host":"${metrics.getHost()}"
   </#if>
-  <#if metrics.getUserAgent()??>
-  ,"user-agent":"${metrics.getUserAgent()}"
+  <#if metrics.getUserAgent()?? || pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()!""}"
   </#if>
   <#if metrics.getUser()??>
   ,"user":"${metrics.getUser()}"

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/index/request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/index/request.ftl
@@ -49,8 +49,8 @@
   <#if metrics.getHost()??>
   ,"host":"${metrics.getHost()}"
   </#if>
-  <#if metrics.getUserAgent()??>
-  ,"user-agent":"${metrics.getUserAgent()}"
+  <#if metrics.getUserAgent()?? || pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()!""}"
   </#if>
   <#if metrics.getUser()??>
   ,"user":"${metrics.getUser()}"

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/request.ftl
@@ -52,8 +52,8 @@
   <#if metrics.getMappedPath()??>
   ,"mapped-path":"${metrics.getMappedPath()}"
   </#if>
-  <#if metrics.getUserAgent()??>
-  ,"user-agent":"${metrics.getUserAgent()}"
+  <#if metrics.getUserAgent()??> || pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()!""}"
   </#if>
   <#if metrics.getUser()??>
   ,"user":"${metrics.getUser()}"


### PR DESCRIPTION
…line is enabled and no user-agent is provided for the request

Closes gravitee-io/issues#2256