### PR TITLE
fix: Template mapping of log is incorrect with ES 7.x

### DIFF
--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -5,7 +5,7 @@
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}",
+        "index.refresh_interval": "${refreshInterval}"
         <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
     },
     "mappings": {


### PR DESCRIPTION
This closes gravitee-io/issues#4685