### PR TITLE
fix(elasticsearch): Connector must retry to connect to Elasticsearch when receiving bad info

### DIFF
--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -226,7 +226,14 @@ public class HttpClient implements Client {
                 .get(URL_ROOT)
                 .rxSend()
                 .doOnError(throwable -> logger.error("Unable to get a connection to Elasticsearch: {}", throwable.getMessage()))
-                .map(response -> mapper.readValue(response.bodyAsString(), ElasticsearchInfo.class));
+                .map(response -> {
+                    if (response.statusCode() == HttpStatusCode.OK_200) {
+                        return mapper.readValue(response.bodyAsString(), ElasticsearchInfo.class);
+                    }
+
+                    throw new ElasticsearchException("Unable to retrieve Elasticsearch information: status[" +
+                            response.statusCode()+"] payload: [" + response.bodyAsString() + "]");
+                });
     }
 
     @Override


### PR DESCRIPTION
Closes gravitee-io/issues#4919