### PR TITLE
fix: implement ILM managed indexes in reporter

### DIFF
--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
@@ -86,10 +86,10 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 					new Elastic5xBeanRegistrer().register(beanFactory, configuration.isPerTypeIndex());
 					break;
 				case 6:
-					new Elastic6xBeanRegistrer().register(beanFactory);
+					new Elastic6xBeanRegistrer().register(beanFactory, configuration.isIlmManagedIndex());
 					break;
 				case 7:
-					new Elastic7xBeanRegistrer().register(beanFactory);
+					new Elastic7xBeanRegistrer().register(beanFactory, configuration.isIlmManagedIndex());
 					break;
 				default:
 					registered = false;

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -55,6 +55,12 @@ public class ReporterConfiguration {
 	private boolean perTypeIndex;
 
 	/**
+	 * Index mode normal (daily index) vs ILM (managed by ILM)
+	 */
+	@Value("${reporters.elasticsearch.index_mode:daily}")
+	private String indexMode;
+
+	/**
 	 * Request actions max by bulk
 	 */
 	@Value("${reporters.elasticsearch.bulk.actions:1000}")
@@ -499,5 +505,9 @@ public class ReporterConfiguration {
 
 	public void setExtendedSettingsTemplate(String extendedSettingsTemplate) {
 		this.extendedSettingsTemplate = extendedSettingsTemplate;
+	}
+
+	public boolean isIlmManagedIndex() {
+		return "ilm".equalsIgnoreCase(indexMode);
 	}
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/AbstractPerTypeIndexNameGenerator.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/AbstractPerTypeIndexNameGenerator.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.indexer.name;
+
+import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.api.health.EndpointStatus;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.log.Log;
+import io.gravitee.reporter.api.monitor.Monitor;
+
+import java.time.Instant;
+
+/**
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractPerTypeIndexNameGenerator extends AbstractIndexNameGenerator {
+
+    public abstract String generate(String type, Instant timestamp);
+
+    @Override
+    public String generate(Reportable reportable) {
+        String type = null;
+        if (reportable instanceof Metrics) {
+            type = Type.REQUEST.getType();
+        } else if (reportable instanceof Log) {
+            type = Type.LOG.getType();
+        } else if (reportable instanceof Monitor) {
+            type = Type.MONITOR.getType();
+        } else if (reportable instanceof EndpointStatus) {
+            type = Type.HEALTH_CHECK.getType();
+        }
+
+        return generate(type, reportable.timestamp());
+    }
+}

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeAndDateIndexNameGenerator.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeAndDateIndexNameGenerator.java
@@ -21,17 +21,17 @@ import java.time.Instant;
 /**
  * @author GraviteeSource Team
  */
-public class PerTypeIndexNameGenerator extends AbstractPerTypeIndexNameGenerator {
+public class PerTypeAndDateIndexNameGenerator extends AbstractPerTypeIndexNameGenerator {
 
     private String indexNameTemplate;
 
     @PostConstruct
     public void initialize() {
-        indexNameTemplate = configuration.getIndexName() + "-%s";
+        indexNameTemplate = configuration.getIndexName() + "-%s-%s";
     }
 
     @Override
     public String generate(String type, Instant timestamp) {
-        return String.format(indexNameTemplate, type);
+        return String.format(indexNameTemplate, type, sdf.format(timestamp));
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
@@ -16,6 +16,7 @@
 package io.gravitee.reporter.elasticsearch.spring.context;
 
 import io.gravitee.reporter.elasticsearch.indexer.es6.ES6BulkIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.es6.ES6IndexPreparer;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -27,14 +28,14 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
  */
 public class Elastic6xBeanRegistrer {
 
-    public void register(DefaultListableBeanFactory beanFactory) {
+    public void register(DefaultListableBeanFactory beanFactory, boolean isIlmManagedIndex) {
         BeanDefinitionBuilder beanIndexer = BeanDefinitionBuilder.rootBeanDefinition(ES6BulkIndexer.class);
         beanFactory.registerBeanDefinition("indexer", beanIndexer.getBeanDefinition());
 
         BeanDefinitionBuilder beanIndexPreparer = BeanDefinitionBuilder.rootBeanDefinition(ES6IndexPreparer.class);
         beanFactory.registerBeanDefinition("indexPreparer", beanIndexPreparer.getBeanDefinition());
 
-        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(PerTypeIndexNameGenerator.class);
+        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(isIlmManagedIndex ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class);
         beanFactory.registerBeanDefinition("indexNameGenerator", beanIndexNameGenerator.getBeanDefinition());
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
@@ -16,6 +16,7 @@
 package io.gravitee.reporter.elasticsearch.spring.context;
 
 import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -27,14 +28,14 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
  */
 public class Elastic7xBeanRegistrer {
 
-    public void register(DefaultListableBeanFactory beanFactory) {
+    public void register(DefaultListableBeanFactory beanFactory, boolean isIlmManagedIndex) {
         BeanDefinitionBuilder beanIndexer = BeanDefinitionBuilder.rootBeanDefinition(ES7BulkIndexer.class);
         beanFactory.registerBeanDefinition("indexer", beanIndexer.getBeanDefinition());
 
         BeanDefinitionBuilder beanIndexPreparer = BeanDefinitionBuilder.rootBeanDefinition(ES7IndexPreparer.class);
         beanFactory.registerBeanDefinition("indexPreparer", beanIndexPreparer.getBeanDefinition());
 
-        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(PerTypeIndexNameGenerator.class);
+        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(isIlmManagedIndex ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class);
         beanFactory.registerBeanDefinition("indexNameGenerator", beanIndexNameGenerator.getBeanDefinition());
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-health.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-health.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-log.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-log.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-monitor.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-monitor.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
         "index.number_of_shards":${numberOfShards},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
         "index.number_of_shards":${numberOfShards},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
         "index.number_of_shards":${numberOfShards},

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["${indexName}-*"],
+    "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
         "index.number_of_shards":${numberOfShards},

--- a/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeAndDateIndexNameGeneratorTest.java
+++ b/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeAndDateIndexNameGeneratorTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.indexer.name;
+
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class PerTypeAndDateIndexNameGeneratorTest {
+
+    private PerTypeAndDateIndexNameGenerator indexNameGenerator = new PerTypeAndDateIndexNameGenerator();
+
+    @Test
+    public void generate_should_generate_index_name_with_type_and_date() {
+        indexNameGenerator.configuration = new ReporterConfiguration();
+        indexNameGenerator.configuration.setIndexName("indexName");
+        indexNameGenerator.initialize();
+
+        String indexName = indexNameGenerator.generate("indextype", Instant.parse("2018-04-28T18:35:24.00Z"));
+
+        assertEquals(indexName, "indexName-indextype-2018.04.28");
+    }
+}

--- a/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeIndexNameGeneratorTest.java
+++ b/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/indexer/name/PerTypeIndexNameGeneratorTest.java
@@ -15,23 +15,25 @@
  */
 package io.gravitee.reporter.elasticsearch.indexer.name;
 
-import javax.annotation.PostConstruct;
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import org.junit.Test;
+
 import java.time.Instant;
 
-/**
- * @author GraviteeSource Team
- */
-public class PerTypeIndexNameGenerator extends AbstractPerTypeIndexNameGenerator {
+import static org.junit.Assert.assertEquals;
 
-    private String indexNameTemplate;
+public class PerTypeIndexNameGeneratorTest {
 
-    @PostConstruct
-    public void initialize() {
-        indexNameTemplate = configuration.getIndexName() + "-%s";
-    }
+    private PerTypeIndexNameGenerator indexNameGenerator = new PerTypeIndexNameGenerator();
 
-    @Override
-    public String generate(String type, Instant timestamp) {
-        return String.format(indexNameTemplate, type);
+    @Test
+    public void generate_should_generate_index_name_with_type_and_no_date() {
+        indexNameGenerator.configuration = new ReporterConfiguration();
+        indexNameGenerator.configuration.setIndexName("indexName");
+        indexNameGenerator.initialize();
+
+        String indexName = indexNameGenerator.generate("indextype", Instant.parse("2018-04-28T18:35:24.00Z"));
+
+        assertEquals(indexName, "indexName-indextype");
     }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6507

ILM managed indexes names aren't suffixed by the date.
It's properly handled in repository side for ES>=6, but not in reporter side.

So, when user uses gravitee.analytics.elasticsearch.index_mode=ilm parameter in rest API,
It doesn't read on the same indexes gateway is writing on.

This modification implements ILM managed index on reporter side,
That can be enabled with gravitee.reporters.elasticsearch.index_mode=ilm parameter.

I didn't put much effort on code refactoring here, cause some of those components will be refactored during openSearch support implementation (see https://github.com/gravitee-io/issues/issues/6423)