### PR TITLE
Feat/6423 opensearch support

### DIFF
--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
@@ -56,4 +56,19 @@ public class Version {
         }
         return majorVersion;
     }
+
+    public boolean canUseTypeRequests() {
+        // from ES version 7, specifying types in requests is deprecated
+        return getMajorVersion() < 7;
+    }
+
+    public boolean canUseMultiTypeIndex() {
+        // from ES version 6, using multiple mapping types is no more supported
+        return getMajorVersion() < 6;
+    }
+
+    public boolean canUseIlmIndex() {
+        // from ES version 6, we can use ILM indexes
+        return getMajorVersion() >= 6;
+    }
 }

--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
@@ -27,10 +27,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Version {
 
+    private static final String OPENSEARCH_DISTRIBUTION = "opensearch";
+
     private String number;
 
     @JsonProperty("lucene_version")
     private String luceneVersion;
+
+    private String distribution;
 
     private int majorVersion = -1;
 
@@ -50,6 +54,10 @@ public class Version {
         this.luceneVersion = luceneVersion;
     }
 
+    public void setDistribution(String distribution) {
+        this.distribution = distribution;
+    }
+
     public int getMajorVersion() {
         if (majorVersion == -1) {
             majorVersion = Integer.valueOf(getNumber().substring(0, 1));
@@ -57,18 +65,22 @@ public class Version {
         return majorVersion;
     }
 
+    public boolean isOpenSearch() {
+        return OPENSEARCH_DISTRIBUTION.equals(distribution);
+    }
+
     public boolean canUseTypeRequests() {
         // from ES version 7, specifying types in requests is deprecated
-        return getMajorVersion() < 7;
+        return !isOpenSearch() && getMajorVersion() < 7;
     }
 
     public boolean canUseMultiTypeIndex() {
         // from ES version 6, using multiple mapping types is no more supported
-        return getMajorVersion() < 6;
+        return !isOpenSearch() && getMajorVersion() < 6;
     }
 
     public boolean canUseIlmIndex() {
         // from ES version 6, we can use ILM indexes
-        return getMajorVersion() >= 6;
+        return isOpenSearch() || getMajorVersion() >= 6;
     }
 }

--- a/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
+++ b/gravitee-common-elasticsearch/src/main/java/io/gravitee/elasticsearch/version/Version.java
@@ -79,8 +79,8 @@ public class Version {
         return !isOpenSearch() && getMajorVersion() < 6;
     }
 
-    public boolean canUseIlmIndex() {
-        // from ES version 6, we can use ILM indexes
+    public boolean canUseIlmManagedIndex() {
+        // from ES version 6, we can use ILM managed indexes, which names are not suffixed by date
         return isOpenSearch() || getMajorVersion() >= 6;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
@@ -74,7 +74,7 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 			}
 
 			DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
-			elasticsearchBeanRegister.register(beanFactory, configuration.isPerTypeIndex());
+			elasticsearchBeanRegister.register(beanFactory, configuration);
 
 			IndexPreparer preparer = applicationContext.getBean(IndexPreparer.class);
 			preparer

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
@@ -27,9 +27,7 @@ import io.gravitee.reporter.api.monitor.Monitor;
 import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.Indexer;
 import io.gravitee.reporter.elasticsearch.mapping.IndexPreparer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic5xBeanRegistrer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic6xBeanRegistrer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic7xBeanRegistrer;
+import io.gravitee.reporter.elasticsearch.spring.context.*;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Observable;
@@ -48,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class ElasticsearchReporter extends AbstractService implements Reporter {
 
-	private final Logger logger = LoggerFactory.getLogger(ElasticsearchReporter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchReporter.class);
 
 	@Autowired
 	private Client client;
@@ -65,63 +63,41 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 	protected void doStart() throws Exception {
 		if (configuration.isEnabled()) {
 			super.doStart();
+			LOGGER.info("Starting Elastic reporter engine...");
 
-			logger.info("Starting Elastic reporter engine...");
-
-			// Wait for a connection to ES and retry each 5 seconds
-			Single<ElasticsearchInfo> singleVersion = client.getInfo()
-					.retryWhen(error -> error.flatMap(
-							throwable -> Observable.just(new Object()).delay(5, TimeUnit.SECONDS).toFlowable(BackpressureStrategy.LATEST)));
-
-			singleVersion.subscribe();
-
-			ElasticsearchInfo version = singleVersion.blockingGet();
-
-			boolean registered = true;
+			ElasticsearchInfo elasticsearchInfo = retreiveElasticSearchInfo();
+			AbstractElasticBeanRegistrer elasticsearchBeanRegister = getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+			if (elasticsearchBeanRegister == null) {
+				LOGGER.error("ElasticSearch version {} is not supported by this Elasticsearch connector", elasticsearchInfo.getVersion().getNumber());
+				LOGGER.info("Starting Elastic reporter engine... ERROR");
+				return;
+			}
 
 			DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
+			elasticsearchBeanRegister.register(beanFactory, configuration.isPerTypeIndex());
 
-			switch (version.getVersion().getMajorVersion()) {
-				case 5:
-					new Elastic5xBeanRegistrer().register(beanFactory, configuration.isPerTypeIndex());
-					break;
-				case 6:
-					new Elastic6xBeanRegistrer().register(beanFactory, configuration.isIlmManagedIndex());
-					break;
-				case 7:
-					new Elastic7xBeanRegistrer().register(beanFactory, configuration.isIlmManagedIndex());
-					break;
-				default:
-					registered = false;
-					logger.error("Version {} is not supported by this Elasticsearch connector", version);
-			}
+			IndexPreparer preparer = applicationContext.getBean(IndexPreparer.class);
+			preparer
+				.prepare()
+				.doOnComplete(() -> {
+					LOGGER.info("Starting Elastic reporter engine... DONE");
+				})
+				.subscribe(new CompletableObserver() {
+					@Override
+					public void onSubscribe(Disposable d) {}
 
-			if (registered) {
-				IndexPreparer preparer = applicationContext.getBean(IndexPreparer.class);
-				preparer
-						.prepare()
-						.doOnComplete(() -> {
-							logger.info("Starting Elastic reporter engine... DONE");
-						})
-						.subscribe(new CompletableObserver() {
-							@Override
-							public void onSubscribe(Disposable d) {}
+					@Override
+					public void onComplete() {
+						LOGGER.info("Index mapping template successfully defined");
+					}
 
-							@Override
-							public void onComplete() {
-								logger.info("Index mapping template successfully defined");
-							}
+					@Override
+					public void onError(Throwable t) {
+						LOGGER.error("An error occurs while creating index mapping template", t);
+					}
+				});
 
-							@Override
-							public void onError(Throwable t) {
-								logger.error("An error occurs while creating index mapping template", t);
-							}
-						});
-
-				indexer = applicationContext.getBean(Indexer.class);
-			} else {
-				logger.info("Starting Elastic reporter engine... ERROR");
-			}
+			indexer = applicationContext.getBean(Indexer.class);
 		}
 	}
 
@@ -149,8 +125,25 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 	protected void doStop() throws Exception {
 		if (configuration.isEnabled()) {
 			super.doStop();
+			LOGGER.info("Stopping Elastic reporter engine... DONE");
+		}
+	}
 
-			logger.info("Stopping Elastic reporter engine... DONE");
+	private ElasticsearchInfo retreiveElasticSearchInfo() {
+		// Wait for a connection to ES and retry each 5 seconds
+		Single<ElasticsearchInfo> elasticsearchInfoSingle = client.getInfo()
+				.retryWhen(error -> error.flatMap(
+						throwable -> Observable.just(new Object()).delay(5, TimeUnit.SECONDS).toFlowable(BackpressureStrategy.LATEST)));
+		elasticsearchInfoSingle.subscribe();
+		return elasticsearchInfoSingle.blockingGet();
+	}
+
+	protected AbstractElasticBeanRegistrer getBeanRegistrerFromElasticsearchInfo(ElasticsearchInfo elasticsearchInfo) {
+		switch (elasticsearchInfo.getVersion().getMajorVersion()) {
+			case 5: return new Elastic5xBeanRegistrer();
+			case 6: return new Elastic6xBeanRegistrer();
+			case 7: return new Elastic7xBeanRegistrer();
+			default: return null;
 		}
 	}
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporter.java
@@ -68,7 +68,7 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 			ElasticsearchInfo elasticsearchInfo = retreiveElasticSearchInfo();
 			AbstractElasticBeanRegistrer elasticsearchBeanRegister = getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
 			if (elasticsearchBeanRegister == null) {
-				LOGGER.error("ElasticSearch version {} is not supported by this Elasticsearch connector", elasticsearchInfo.getVersion().getNumber());
+				LOGGER.error("{} version {} is not supported by this connector", elasticsearchInfo.getVersion().isOpenSearch() ? "OpenSearch" : "ElasticSearch", elasticsearchInfo.getVersion().getNumber());
 				LOGGER.info("Starting Elastic reporter engine... ERROR");
 				return;
 			}
@@ -139,6 +139,13 @@ public class ElasticsearchReporter extends AbstractService implements Reporter {
 	}
 
 	protected AbstractElasticBeanRegistrer getBeanRegistrerFromElasticsearchInfo(ElasticsearchInfo elasticsearchInfo) {
+		if (elasticsearchInfo.getVersion().isOpenSearch()) {
+			if (elasticsearchInfo.getVersion().getMajorVersion() == 1) {
+				return new OpenSearchBeanRegistrer();
+			}
+			return null;
+		}
+
 		switch (elasticsearchInfo.getVersion().getMajorVersion()) {
 			case 5: return new Elastic5xBeanRegistrer();
 			case 6: return new Elastic6xBeanRegistrer();

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/AbstractElasticBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/AbstractElasticBeanRegistrer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.spring.context;
+
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+/**
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractElasticBeanRegistrer {
+
+    protected abstract Class<? extends AbstractIndexer> getIndexerClass();
+    protected abstract Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex);
+    protected abstract Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex);
+
+    public void register(DefaultListableBeanFactory beanFactory, boolean perTypeIndex) {
+        beanFactory.registerBeanDefinition("indexer", BeanDefinitionBuilder.rootBeanDefinition(getIndexerClass()).getBeanDefinition());
+        beanFactory.registerBeanDefinition("indexPreparer", BeanDefinitionBuilder.rootBeanDefinition(getIndexPreparerClass(perTypeIndex)).getBeanDefinition());
+        beanFactory.registerBeanDefinition("indexNameGenerator", BeanDefinitionBuilder.rootBeanDefinition(getIndexNameGeneratorClass(perTypeIndex)).getBeanDefinition());
+    }
+}

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/AbstractElasticBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/AbstractElasticBeanRegistrer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
@@ -27,12 +28,12 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 public abstract class AbstractElasticBeanRegistrer {
 
     protected abstract Class<? extends AbstractIndexer> getIndexerClass();
-    protected abstract Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex);
-    protected abstract Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex);
+    protected abstract Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration);
+    protected abstract Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration);
 
-    public void register(DefaultListableBeanFactory beanFactory, boolean perTypeIndex) {
+    public void register(DefaultListableBeanFactory beanFactory, ReporterConfiguration configuration) {
         beanFactory.registerBeanDefinition("indexer", BeanDefinitionBuilder.rootBeanDefinition(getIndexerClass()).getBeanDefinition());
-        beanFactory.registerBeanDefinition("indexPreparer", BeanDefinitionBuilder.rootBeanDefinition(getIndexPreparerClass(perTypeIndex)).getBeanDefinition());
-        beanFactory.registerBeanDefinition("indexNameGenerator", BeanDefinitionBuilder.rootBeanDefinition(getIndexNameGeneratorClass(perTypeIndex)).getBeanDefinition());
+        beanFactory.registerBeanDefinition("indexPreparer", BeanDefinitionBuilder.rootBeanDefinition(getIndexPreparerClass(configuration)).getBeanDefinition());
+        beanFactory.registerBeanDefinition("indexNameGenerator", BeanDefinitionBuilder.rootBeanDefinition(getIndexNameGeneratorClass(configuration)).getBeanDefinition());
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic5xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic5xBeanRegistrer.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es5.ES5BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.MultiTypeIndexNameGenerator;
-import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es5.ES5MultiTypeIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es5.ES5PerTypeIndexPreparer;
@@ -36,12 +37,12 @@ public class Elastic5xBeanRegistrer extends AbstractElasticBeanRegistrer {
     }
 
     @Override
-    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
-        return perTypeIndex ? ES5PerTypeIndexPreparer.class : ES5MultiTypeIndexPreparer.class;
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration) {
+        return configuration.isPerTypeIndex() ? ES5PerTypeIndexPreparer.class : ES5MultiTypeIndexPreparer.class;
     }
 
     @Override
-    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
-        return perTypeIndex ? PerTypeIndexNameGenerator.class : MultiTypeIndexNameGenerator.class;
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration) {
+        return configuration.isPerTypeIndex() ? PerTypeAndDateIndexNameGenerator.class : MultiTypeIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic5xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic5xBeanRegistrer.java
@@ -15,32 +15,33 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es5.ES5BulkIndexer;
-import io.gravitee.reporter.elasticsearch.indexer.name.IndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.MultiTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
-import io.gravitee.reporter.elasticsearch.mapping.IndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es5.ES5MultiTypeIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es5.ES5PerTypeIndexPreparer;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class Elastic5xBeanRegistrer {
+public class Elastic5xBeanRegistrer extends AbstractElasticBeanRegistrer {
 
-    public void register(DefaultListableBeanFactory beanFactory, boolean perTypeIndex) {
-        BeanDefinitionBuilder beanIndexer = BeanDefinitionBuilder.rootBeanDefinition(ES5BulkIndexer.class);
-        beanFactory.registerBeanDefinition("indexer", beanIndexer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexer> getIndexerClass() {
+        return ES5BulkIndexer.class;
+    }
 
-        Class<? extends IndexPreparer> indexPreparerClass = (perTypeIndex) ? ES5PerTypeIndexPreparer.class : ES5MultiTypeIndexPreparer.class;
-        BeanDefinitionBuilder beanIndexPreparer = BeanDefinitionBuilder.rootBeanDefinition(indexPreparerClass);
-        beanFactory.registerBeanDefinition("indexPreparer", beanIndexPreparer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+        return perTypeIndex ? ES5PerTypeIndexPreparer.class : ES5MultiTypeIndexPreparer.class;
+    }
 
-        Class<? extends IndexNameGenerator> indexNameGeneratorClass = (perTypeIndex) ? PerTypeIndexNameGenerator.class : MultiTypeIndexNameGenerator.class;
-        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(indexNameGeneratorClass);
-        beanFactory.registerBeanDefinition("indexNameGenerator", beanIndexNameGenerator.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
+        return perTypeIndex ? PerTypeIndexNameGenerator.class : MultiTypeIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es6.ES6BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es6.ES6IndexPreparer;
@@ -34,12 +36,12 @@ public class Elastic6xBeanRegistrer extends AbstractElasticBeanRegistrer {
     }
 
     @Override
-    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration) {
         return ES6IndexPreparer.class;
     }
 
     @Override
-    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
-        return PerTypeIndexNameGenerator.class;
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration) {
+        return configuration.isIlmManagedIndex() ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic6xBeanRegistrer.java
@@ -15,27 +15,31 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es6.ES6BulkIndexer;
-import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es6.ES6IndexPreparer;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class Elastic6xBeanRegistrer {
+public class Elastic6xBeanRegistrer extends AbstractElasticBeanRegistrer {
 
-    public void register(DefaultListableBeanFactory beanFactory, boolean isIlmManagedIndex) {
-        BeanDefinitionBuilder beanIndexer = BeanDefinitionBuilder.rootBeanDefinition(ES6BulkIndexer.class);
-        beanFactory.registerBeanDefinition("indexer", beanIndexer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexer> getIndexerClass() {
+        return ES6BulkIndexer.class;
+    }
 
-        BeanDefinitionBuilder beanIndexPreparer = BeanDefinitionBuilder.rootBeanDefinition(ES6IndexPreparer.class);
-        beanFactory.registerBeanDefinition("indexPreparer", beanIndexPreparer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+        return ES6IndexPreparer.class;
+    }
 
-        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(isIlmManagedIndex ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class);
-        beanFactory.registerBeanDefinition("indexNameGenerator", beanIndexNameGenerator.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
+        return PerTypeIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
@@ -34,12 +36,12 @@ public class Elastic7xBeanRegistrer extends AbstractElasticBeanRegistrer {
     }
 
     @Override
-    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration) {
         return ES7IndexPreparer.class;
     }
 
     @Override
-    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
-        return PerTypeIndexNameGenerator.class;
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration) {
+        return configuration.isIlmManagedIndex() ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic7xBeanRegistrer.java
@@ -15,27 +15,31 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
-import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class Elastic7xBeanRegistrer {
+public class Elastic7xBeanRegistrer extends AbstractElasticBeanRegistrer {
 
-    public void register(DefaultListableBeanFactory beanFactory, boolean isIlmManagedIndex) {
-        BeanDefinitionBuilder beanIndexer = BeanDefinitionBuilder.rootBeanDefinition(ES7BulkIndexer.class);
-        beanFactory.registerBeanDefinition("indexer", beanIndexer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexer> getIndexerClass() {
+        return ES7BulkIndexer.class;
+    }
 
-        BeanDefinitionBuilder beanIndexPreparer = BeanDefinitionBuilder.rootBeanDefinition(ES7IndexPreparer.class);
-        beanFactory.registerBeanDefinition("indexPreparer", beanIndexPreparer.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+        return ES7IndexPreparer.class;
+    }
 
-        BeanDefinitionBuilder beanIndexNameGenerator = BeanDefinitionBuilder.rootBeanDefinition(isIlmManagedIndex ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class);
-        beanFactory.registerBeanDefinition("indexNameGenerator", beanIndexNameGenerator.getBeanDefinition());
+    @Override
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
+        return PerTypeIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/OpenSearchBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/OpenSearchBeanRegistrer.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.reporter.elasticsearch.spring.context;
 
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
@@ -33,12 +35,12 @@ public class OpenSearchBeanRegistrer extends AbstractElasticBeanRegistrer {
     }
 
     @Override
-    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration) {
         return ES7IndexPreparer.class;
     }
 
     @Override
-    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
-        return PerTypeIndexNameGenerator.class;
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration) {
+        return configuration.isIlmManagedIndex() ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class;
     }
 }

--- a/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/OpenSearchBeanRegistrer.java
+++ b/gravitee-reporter-elasticsearch/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/OpenSearchBeanRegistrer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.spring.context;
+
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class OpenSearchBeanRegistrer extends AbstractElasticBeanRegistrer {
+
+    @Override
+    protected Class<? extends AbstractIndexer> getIndexerClass() {
+        return ES7BulkIndexer.class;
+    }
+
+    @Override
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(boolean perTypeIndex) {
+        return ES7IndexPreparer.class;
+    }
+
+    @Override
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(boolean perTypeIndex) {
+        return PerTypeIndexNameGenerator.class;
+    }
+}

--- a/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporterTest.java
+++ b/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporterTest.java
@@ -29,10 +29,7 @@ import io.gravitee.reporter.api.monitor.Monitor;
 import io.gravitee.reporter.api.monitor.OsInfo;
 import io.gravitee.reporter.api.monitor.ProcessInfo;
 import io.gravitee.reporter.elasticsearch.spring.ElasticsearchReporterConfigurationTest;
-import io.gravitee.reporter.elasticsearch.spring.context.AbstractElasticBeanRegistrer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic5xBeanRegistrer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic6xBeanRegistrer;
-import io.gravitee.reporter.elasticsearch.spring.context.Elastic7xBeanRegistrer;
+import io.gravitee.reporter.elasticsearch.spring.context.*;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
@@ -297,6 +294,32 @@ public class ElasticsearchReporterTest {
         AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
 
         assertTrue(beanRegistrer instanceof Elastic7xBeanRegistrer);
+    }
+
+    @Test
+    public void getBeanRegistrer_should_instantiate_opensearch_registrer_when_opensearch_distribution_version_1() {
+        Version version = new Version();
+        version.setNumber("1.12.7");
+        version.setDistribution("opensearch");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertTrue(beanRegistrer instanceof OpenSearchBeanRegistrer);
+    }
+
+    @Test
+    public void getBeanRegistrer_should_instantiate_opensearch_registrer_when_opensearch_distribution_higher_version() {
+        Version version = new Version();
+        version.setNumber("2.12.7");
+        version.setDistribution("opensearch");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertNull(beanRegistrer);
     }
 
     @Test

--- a/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporterTest.java
+++ b/gravitee-reporter-elasticsearch/src/test/java/io/gravitee/reporter/elasticsearch/ElasticsearchReporterTest.java
@@ -17,6 +17,8 @@ package io.gravitee.reporter.elasticsearch;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.elasticsearch.version.Version;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
 import io.gravitee.reporter.api.health.EndpointStatus;
@@ -27,6 +29,10 @@ import io.gravitee.reporter.api.monitor.Monitor;
 import io.gravitee.reporter.api.monitor.OsInfo;
 import io.gravitee.reporter.api.monitor.ProcessInfo;
 import io.gravitee.reporter.elasticsearch.spring.ElasticsearchReporterConfigurationTest;
+import io.gravitee.reporter.elasticsearch.spring.context.AbstractElasticBeanRegistrer;
+import io.gravitee.reporter.elasticsearch.spring.context.Elastic5xBeanRegistrer;
+import io.gravitee.reporter.elasticsearch.spring.context.Elastic6xBeanRegistrer;
+import io.gravitee.reporter.elasticsearch.spring.context.Elastic7xBeanRegistrer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
@@ -46,6 +52,8 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static io.gravitee.reporter.api.http.SecurityType.API_KEY;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -253,6 +261,54 @@ public class ElasticsearchReporterTest {
 
         metrics1.awaitTerminalEvent();
         metrics1.assertNoErrors();
+    }
+
+    @Test
+    public void getBeanRegistrer_should_instantiate_es5_registrer_when_major_version_is_5() {
+        Version version = new Version();
+        version.setNumber("5.12.7");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertTrue(beanRegistrer instanceof Elastic5xBeanRegistrer);
+    }
+
+    @Test
+    public void getBeanRegistrer_should_instantiate_es6_registrer_when_major_version_is_6() {
+        Version version = new Version();
+        version.setNumber("6.12.7");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertTrue(beanRegistrer instanceof Elastic6xBeanRegistrer);
+    }
+
+    @Test
+    public void getBeanRegistrer_should_instantiate_es7_registrer_when_major_version_is_7() {
+        Version version = new Version();
+        version.setNumber("7.12.7");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertTrue(beanRegistrer instanceof Elastic7xBeanRegistrer);
+    }
+
+    @Test
+    public void getBeanRegistrer_should_return_null_when_unknown_major_version() {
+        Version version = new Version();
+        version.setNumber("9.12.7");
+        ElasticsearchInfo elasticsearchInfo = new ElasticsearchInfo();
+        elasticsearchInfo.setVersion(version);
+
+        AbstractElasticBeanRegistrer beanRegistrer = reporter.getBeanRegistrerFromElasticsearchInfo(elasticsearchInfo);
+
+        assertNull(beanRegistrer);
     }
 
     private Metrics mockRequestMetrics() {

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/AbstractElasticsearchQueryCommand.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/AbstractElasticsearchQueryCommand.java
@@ -122,12 +122,12 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
 
 			result = this.client.search(
 					this.indexNameGenerator.getIndexName(type, from, to, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : type.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : type.getType(),
 					sQuery);
 		} else {
 			result = this.client.search(
 					this.indexNameGenerator.getTodayIndexName(type, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : type.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : type.getType(),
 					sQuery);
 		}
 
@@ -146,12 +146,12 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
 
 			result = this.client.count(
 					this.indexNameGenerator.getIndexName(type, from, to, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : type.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : type.getType(),
 					sQuery);
 		} else {
 			result = this.client.count(
 					this.indexNameGenerator.getTodayIndexName(type, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : type.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : type.getType(),
 					sQuery);
 		}
 

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchHealthCheckRepository.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchHealthCheckRepository.java
@@ -101,7 +101,7 @@ public class ElasticsearchHealthCheckRepository extends AbstractElasticsearchRep
         try {
             final Single<SearchResponse> result = this.client.search(
                     this.indexNameGenerator.getWildcardIndexName(Type.HEALTH_CHECK, clusters),
-                    (info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
+                    !info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
                     sQuery);
 
             SearchResponse searchResponse = result.blockingGet();

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageAvailabilityCommand.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageAvailabilityCommand.java
@@ -22,7 +22,6 @@ import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
-import io.gravitee.repository.healthcheck.query.AbstractQuery;
 import io.gravitee.repository.healthcheck.query.Bucket;
 import io.gravitee.repository.healthcheck.query.FieldBucket;
 import io.gravitee.repository.healthcheck.query.Query;
@@ -82,7 +81,7 @@ public class AverageAvailabilityCommand extends AbstractElasticsearchQueryComman
 
 			final Single<SearchResponse> result = this.client.search(
 					this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, now, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
 					sQuery);
 
 			return this.toAvailabilityResponseResponse(result.blockingGet());

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageDateHistogramCommand.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageDateHistogramCommand.java
@@ -92,7 +92,7 @@ public class AverageDateHistogramCommand extends AbstractElasticsearchQueryComma
 			final String sQuery = this.createQuery(TEMPLATE, dateHistogramQuery, roundedFrom, roundedTo);
 			final Single<SearchResponse> result = this.client.search(
 					this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, to, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
 					sQuery);
 			return this.toAvailabilityResponseResponse(result.blockingGet(), dateHistogramQuery);
 		} catch (Exception eex) {

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageResponseTimeCommand.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageResponseTimeCommand.java
@@ -81,7 +81,7 @@ public class AverageResponseTimeCommand extends AbstractElasticsearchQueryComman
 
 			final Single<SearchResponse> result = this.client.search(
 					this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, now, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
 					sQuery);
 			return this.toAverageResponseTimeResponse(result.blockingGet());
 		} catch (Exception eex) {

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/LogsCommand.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/LogsCommand.java
@@ -83,7 +83,7 @@ public class LogsCommand extends AbstractElasticsearchQueryCommand<LogsResponse>
 
 			final Single<SearchResponse> result = this.client.search(
 					this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, to, clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.HEALTH_CHECK.getType(),
 					sQuery);
 			return this.toLogsResponse(result.blockingGet());
 		} catch (ElasticsearchException eex) {

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -88,7 +88,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
 			if (isEmpty(logQueryString)) {
 				final Single<SearchResponse> result = this.client.search(
 						this.indexNameGenerator.getIndexName(Type.REQUEST, from, to, clusters),
-						(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.REQUEST.getType(),
+						!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.REQUEST.getType(),
 						this.createElasticsearchJsonQuery(query));
 
 				return this.toTabularResponse(result.blockingGet());
@@ -96,7 +96,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
 				final String sQuery = this.createElasticsearchJsonQuery(tabularQueryBuilder.query(logQueryString).build());
 				Single<SearchResponse> result = this.client.search(
 						this.indexNameGenerator.getIndexName(Type.LOG, from, to, clusters),
-						(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.LOG.getType(),
+						!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.LOG.getType(),
 						sQuery);
 
 				final SearchResponse searchResponse = result.blockingGet();
@@ -114,7 +114,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
 					}
 					result = this.client.search(
 							this.indexNameGenerator.getIndexName(Type.REQUEST, from, to, clusters),
-							(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.REQUEST.getType(),
+							!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.REQUEST.getType(),
 							this.createElasticsearchJsonQuery(tqb.build()));
 				}
 
@@ -172,7 +172,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
 		try {
 			Single<SearchResponse> result = this.client.search(
 					(timestamp == null) ? this.indexNameGenerator.getWildcardIndexName(Type.REQUEST, clusters) : this.indexNameGenerator.getIndexName(Type.REQUEST, Instant.ofEpochMilli(timestamp), clusters),
-					(info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.REQUEST.getType(),
+					!info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.REQUEST.getType(),
 					sQuery);
 
 			SearchResponse searchResponse = result.blockingGet();
@@ -193,7 +193,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
 				searchHitIndex = this.indexNameGenerator.getIndexName(Type.LOG, Instant.ofEpochMilli(timestamp), clusters);
 			}
 
-			result = this.client.search(searchHitIndex, (info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.LOG.getType(), sQuery);
+			result = this.client.search(searchHitIndex, !info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.LOG.getType(), sQuery);
 			searchResponse = result.blockingGet();
 
 			JsonNode log = null;

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
@@ -75,7 +75,7 @@ public class ElasticsearchMonitoringRepository extends AbstractElasticsearchRepo
         try {
             final Single<SearchResponse> result = this.client.search(
                     this.indexNameGenerator.getTodayIndexName(Type.MONITOR, clusters),
-                    (info.getVersion().getMajorVersion() > 6) ? Type.DOC.getType() : Type.MONITOR.getType(),
+                    !info.getVersion().canUseTypeRequests() ? Type.DOC.getType() : Type.MONITOR.getType(),
                     sQuery);
 
             final SearchHits hits = result.blockingGet().getSearchHits();

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
@@ -117,9 +117,9 @@ public class ElasticsearchRepositoryConfiguration {
 
     @Bean
     public IndexNameGenerator indexNameGenerator(RepositoryConfiguration repositoryConfiguration, ElasticsearchInfo info) {
-        if (info.getVersion().getMajorVersion() >= 6 && repositoryConfiguration.isILMIndex()) {
+        if (info.getVersion().canUseIlmIndex() && repositoryConfiguration.isILMIndex()) {
             return new ILMIndexNameGenerator(repositoryConfiguration.getIndexName());
-        } else if (info.getVersion().getMajorVersion() >= 6 || repositoryConfiguration.isPerTypeIndex()) {
+        } else if (!info.getVersion().canUseMultiTypeIndex() || repositoryConfiguration.isPerTypeIndex()) {
             return new PerTypeIndexNameGenerator(repositoryConfiguration.getIndexName());
         } else {
             return new MultiTypeIndexNameGenerator(repositoryConfiguration.getIndexName());

--- a/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
+++ b/gravitee-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
@@ -117,7 +117,7 @@ public class ElasticsearchRepositoryConfiguration {
 
     @Bean
     public IndexNameGenerator indexNameGenerator(RepositoryConfiguration repositoryConfiguration, ElasticsearchInfo info) {
-        if (info.getVersion().canUseIlmIndex() && repositoryConfiguration.isILMIndex()) {
+        if (info.getVersion().canUseIlmManagedIndex() && repositoryConfiguration.isILMIndex()) {
             return new ILMIndexNameGenerator(repositoryConfiguration.getIndexName());
         } else if (!info.getVersion().canUseMultiTypeIndex() || repositoryConfiguration.isPerTypeIndex()) {
             return new PerTypeIndexNameGenerator(repositoryConfiguration.getIndexName());

--- a/gravitee-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommandTest.java
+++ b/gravitee-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommandTest.java
@@ -73,7 +73,7 @@ public class DateHistogramQueryCommandTest {
         when(dateHistogramQuery.timeRange()).thenReturn(timeRangeFilter);
         when(timeRangeFilter.range()).thenReturn(dateRange);
         when(info.getVersion()).thenReturn(version);
-        when(version.getMajorVersion()).thenReturn(6);
+        when(version.canUseTypeRequests()).thenReturn(true);
 
         checkDateRange(1561477219132L, 1564069219132L, 600000);
         checkDateRange(1561477219132L, 1564069219132L, 43200000);

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>io.gravitee.elasticsearch</groupId>
 	<artifactId>gravitee-elasticsearch</artifactId>
-    <version>3.10.0-SNAPSHOT</version>
+	<version>3.10.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Gravitee.io APIM - Elasticsearch Connector</name>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6423

This PR adds support for OpenSearch in elasticSearch repository and reporter.
It will behave exactly as ES7.

ElasticSearch versions are identified by the major version exposed by ES endpoint.
OpenSearch is identified by the "distribution" exposed by ES endpoint.

This PR contains :
- a refactoring to avoid BeanRegistrer code duplication
- a refactoring to handle elasticSearch capabilities in Version.java, instead of duplicating versions conditions everywhere
- a report of the fix about ILM indexes : https://github.com/gravitee-io/issues/issues/6507
- the OpenSearch support feature
 
