### PR TITLE
fix(health): parse headers according to new data model

### DIFF
--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es5x/index/health.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es5x/index/health.ftl
@@ -27,15 +27,17 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-                <#list step.getRequest().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
+            <#list step.getRequest().getHeaders().names() as header>
+                "${header}": [
+                <#list step.getRequest().getHeaders().getAll(header) as value>
+                    <#if value??>
+                        "${value?j_string}"
                         <#sep>,</#sep>
-                    </#list>
-                ]
-                    <#sep>,</#sep>
+                    </#if>
                 </#list>
+                ]
+                <#sep>,</#sep>
+            </#list>
             }
             </#if>
         },
@@ -46,13 +48,15 @@
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
-                        <#sep>,</#sep>
+                <#list step.getResponse().getHeaders().names() as header>
+                    "${header}": [
+                    <#list step.getResponse().getHeaders().getAll(header) as value>
+                        <#if value??>
+                            "${value?j_string}"
+                            <#sep>,</#sep>
+                        </#if>
                     </#list>
-                ]
+                    ]
                     <#sep>,</#sep>
                 </#list>
             }

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/index/health.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es6x/index/health.ftl
@@ -27,32 +27,36 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-                <#list step.getRequest().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
+            <#list step.getRequest().getHeaders().names() as header>
+                "${header}": [
+                <#list step.getRequest().getHeaders().getAll(header) as value>
+                    <#if value??>
+                        "${value?j_string}"
                         <#sep>,</#sep>
-                    </#list>
-                ]
-                    <#sep>,</#sep>
+                    </#if>
                 </#list>
+                ]
+                <#sep>,</#sep>
+            </#list>
             }
             </#if>
         },
-        "response": {
+       "response": {
             "status":${step.getResponse().getStatus()}
             <#if step.getResponse().getBody()??>
             ,"body":"${step.getResponse().getBody()?j_string}"
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
-                        <#sep>,</#sep>
+                <#list step.getResponse().getHeaders().names() as header>
+                    "${header}": [
+                    <#list step.getResponse().getHeaders().getAll(header) as value>
+                        <#if value??>
+                            "${value?j_string}"
+                            <#sep>,</#sep>
+                        </#if>
                     </#list>
-                ]
+                    ]
                     <#sep>,</#sep>
                 </#list>
             }

--- a/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/index/health.ftl
+++ b/gravitee-reporter-elasticsearch/src/main/resources/freemarker/es7x/index/health.ftl
@@ -27,15 +27,17 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-                <#list step.getRequest().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
+            <#list step.getRequest().getHeaders().names() as header>
+                "${header}": [
+                <#list step.getRequest().getHeaders().getAll(header) as value>
+                    <#if value??>
+                        "${value?j_string}"
                         <#sep>,</#sep>
-                    </#list>
-                ]
-                    <#sep>,</#sep>
+                    </#if>
                 </#list>
+                ]
+                <#sep>,</#sep>
+            </#list>
             }
             </#if>
         },
@@ -46,13 +48,15 @@
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders() as headerKey, headerValue>
-                "${headerKey}": [
-                    <#list headerValue as value>
-                    "${value?j_string}"
-                        <#sep>,</#sep>
+                <#list step.getResponse().getHeaders().names() as header>
+                    "${header}": [
+                    <#list step.getResponse().getHeaders().getAll(header) as value>
+                        <#if value??>
+                            "${value?j_string}"
+                            <#sep>,</#sep>
+                        </#if>
                     </#list>
-                ]
+                    ]
                     <#sep>,</#sep>
                 </#list>
             }


### PR DESCRIPTION
Following the refactor of the HTTP Headers API, a FreeMarker template error was reported in the logs
and the health check was not indexed on endpoint responses containing custom HTTP headers.

see https://github.com/gravitee-io/issues/issues/6964

